### PR TITLE
fix typo/bug in _generate_child_docs

### DIFF
--- a/scripts/encode_data.py
+++ b/scripts/encode_data.py
@@ -76,7 +76,7 @@ class CustomDataLoader:
                 "vector": doc[0],
                 "document": doc[1]
             })
-        return child_docs
+        return document_map
 
     
     def _process_document(self, file) -> None:


### PR DESCRIPTION
There was a bug in _generate_child_docs and this pr fixes it. 
The bug was that it returned the wrong thing